### PR TITLE
ScanSDK.jar was not found when compiling via PGB

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -30,7 +30,7 @@
 				<param name="android-package" value="org.instafret.LaserScannerPlugin" />
 			</feature>
 		</config-file>
-		<source-file src="src/android/libs/ScanSDK.jar" target-dir="libs" />
+		<source-file src="src/android/libs/scanSDK.jar" target-dir="libs" />
 		<source-file src="src/android/LaserScannerPlugin.java" target-dir="src/org/instafret" />
 	</platform>
 


### PR DESCRIPTION
I've renamed the ScanSDK.jar in the plugin.xml because when trying to compile via PhoneGAP Build - it returned an error saying "ScanSDK.jar cannot be found".
Once I renamed to "scanSDK.jar" - it worked :)