### PR TITLE
fix for devices that dont have the scanner

### DIFF
--- a/www/laser_scanner_plugin.js
+++ b/www/laser_scanner_plugin.js
@@ -35,9 +35,8 @@ var laserScannerPlugin = new LaserScannerPlugin();
 
 channel.createSticky('onCordovaConnectionReady');
 
-if(navigator.appVersion.includes("U8000")) {
-  channel.waitForInitialization('onCordovaConnectionReady');
-}
+// quickfix, dont wait because devices with no scanner wont init device ready
+// channel.waitForInitialization('onCordovaConnectionReady');
 
 channel.onCordovaReady.subscribe(function () {
   laserScannerPlugin.getLastBarCode(function (info) {

--- a/www/laser_scanner_plugin.js
+++ b/www/laser_scanner_plugin.js
@@ -34,7 +34,10 @@ LaserScannerPlugin.prototype.getScanVibrateState = function (success_cb, error_c
 var laserScannerPlugin = new LaserScannerPlugin();
 
 channel.createSticky('onCordovaConnectionReady');
-channel.waitForInitialization('onCordovaConnectionReady');
+
+if(navigator.appVersion.includes("U8000")) {
+  channel.waitForInitialization('onCordovaConnectionReady');
+}
 
 channel.onCordovaReady.subscribe(function () {
   laserScannerPlugin.getLastBarCode(function (info) {


### PR DESCRIPTION
Dont wait for init since devices that don't have the hardware scanner wont call device ready.

With this little fix it works fine, both on devices without a scanner and devices with a scanner.